### PR TITLE
Add component to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -4,3 +4,5 @@ reviewers:
 approvers:
 - adambkaplan
 - gabemontero
+component: Storage
+subcomponent: Shared Resource CSI Driver


### PR DESCRIPTION
- Add Storage component to OWNERS
- Add "Shared Resource CSI Driver" subcomponent to OWNERS

This will ensure bugs can be appropriately triaged in Bugzilla.