### PR TITLE
Add operator deploy and e2e script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+_deploy/
 shared-resources-operator

--- a/Makefile
+++ b/Makefile
@@ -42,10 +42,18 @@ clean:
 
 GO_TEST_PACKAGES :=./pkg/... ./cmd/...
 
-# Run e2e tests. Requires openshift-tests in $PATH.
+# Deploy csi-driver-shared-resource-operator to the cluster
 #
-# Example:
-#   make test-e2e
+# Deployment can be tuned using the following environment variables:
+#
+# - OPERATOR_IMAGE: the image for the operator to deploy
+# - DRIVER_IMAGE: the image for the CSI driver
+# - NODE_REGISTRAR_IMAGE: the image for the csi node registrar
+# - LOG_LEVEL: log level for the operator
+deploy:
+	hack/deploy.sh
+
+# Run e2e tests. TODO - actually write e2e tests in golang
 test-e2e:
 	hack/e2e.sh
 

--- a/hack/deploy.sh
+++ b/hack/deploy.sh
@@ -1,0 +1,35 @@
+#! /bin/bash
+
+set -e
+set -o pipefail
+
+# Deploy csi-driver-shared-resource-operator to the cluster
+#
+# Deployment can be tuned using the following environment variables:
+#
+# - OPERATOR_IMAGE: the image for the operator to deploy
+# - DRIVER_IMAGE: the image for the CSI driver
+# - NODE_REGISTRAR_IMAGE: the image for the csi node registrar
+# - LOG_LEVEL: log level for the operator
+
+rm -rf _deploy
+mkdir -p _deploy
+cp -r manifests/* _deploy/
+
+operatorImage=${OPERATOR_IMAGE:-quay.io/openshift/origin-csi-driver-shared-resource-operator:latest}
+driverImage=${DRIVER_IMAGE:-quay.io/openshift/origin-csi-driver-shared-resource:latest}
+nodeRegistrar=${NODE_REGISTRAR_IMAGE:-quay.io/openshift/origin-csi-node-driver-registrar:latest}
+logLevel=${LOG_LEVEL:-5}
+
+echo "Deploying operator image ${operatorImage}"
+echo "Deploying driver image ${driverImage}"
+echo "Deploying node registrar image ${nodeRegistrar}"
+echo "Using log level ${logLevel}"
+
+sed -i -e "s|\${OPERATOR_IMAGE}|${operatorImage}|g" \
+  -e "s|\${DRIVER_IMAGE}|${driverImage}|g" \
+  -e "s|\${NODE_DRIVER_REGISTRAR_IMAGE}|${nodeRegistrar}|g" \
+  -e "s|\${LOG_LEVEL}|${logLevel}|g" \
+  _deploy/09_deployment.yaml
+
+oc apply -f _deploy/

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+# TODO: Write some e2e tests in go and execute them!
+echo "No e2e tests yet!"

--- a/manifests/02_sa.yaml
+++ b/manifests/02_sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: shared-resource-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers

--- a/manifests/03_role.yaml
+++ b/manifests/03_role.yaml
@@ -1,0 +1,49 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: shared-resource-csi-driver-operator-role
+  namespace: openshift-cluster-csi-drivers
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  - services
+  - endpoints
+  - persistentvolumeclaims
+  - events
+  - configmaps
+  - secrets
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - '*'
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - servicemonitors
+  verbs:
+  - get
+  - create
+  - update
+  - patch
+  - delete

--- a/manifests/04_rolebinding.yaml
+++ b/manifests/04_rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: shared-resource-csi-driver-operator-rolebinding
+  namespace: openshift-cluster-csi-drivers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: shared-resource-csi-driver-operator-role
+subjects:
+- kind: ServiceAccount
+  name: shared-resource-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers

--- a/manifests/05_clusterrole.yaml
+++ b/manifests/05_clusterrole.yaml
@@ -1,0 +1,269 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: shared-resource-csi-driver-operator-clusterrole
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - privileged
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - clustercsidrivers
+  verbs:
+  - get
+  - list
+  - watch
+  # The Config Observer controller updates the CR's spec
+  - update
+  - patch
+- apiGroups:
+  - operator.openshift.io
+  resources:
+  - clustercsidrivers/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ''
+  resourceNames:
+  - extension-apiserver-authentication
+  - shared-resource-csi-driver-operator-lock
+  resources:
+  - configmaps
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  - roles
+  - rolebindings
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+  - delete
+  - patch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - serviceaccounts
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - list
+  - create
+  - watch
+  - delete
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - nodes
+  verbs:
+  - '*'
+- apiGroups:
+  - ''
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - delete
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumes
+  verbs:
+  - create
+  - delete
+  - list
+  - get
+  - watch
+  - update
+  - patch
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - ''
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ''
+  resources:
+  - persistentvolumeclaims/status
+  verbs:
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - '*'
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - delete
+  - create
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - volumeattachments/status
+  verbs:
+  - patch
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents/status
+  verbs:
+  - update
+  - patch
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - storageclasses
+  - csinodes
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - '*'
+  resources:
+  - events
+  verbs:
+  - get
+  - patch
+  - create
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotclasses
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshotcontents
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - snapshot.storage.k8s.io
+  resources:
+  - volumesnapshots
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+- apiGroups:
+  - storage.k8s.io
+  resources:
+  - csidrivers
+  verbs:
+  - create
+  - get
+  - list
+  - watch
+  - update
+  - delete
+- apiGroups:
+  - cloudcredential.openshift.io
+  resources:
+  - credentialsrequests
+  verbs:
+  - '*'
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - infrastructures
+  - proxies
+  verbs:
+  - get
+  - list
+  - watch
+# Allow kube-rbac-proxy to create TokenReview to be able to authenticate Prometheus when collecting metrics
+- apiGroups:
+  - "authentication.k8s.io"
+  resources:
+  - "tokenreviews"
+  verbs:
+  - "create"

--- a/manifests/06_clusterrolebinding.yaml
+++ b/manifests/06_clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: shared-resource-csi-driver-operator-clusterrolebinding
+subjects:
+  - kind: ServiceAccount
+    name: shared-resource-csi-driver-operator
+    namespace: openshift-cluster-csi-drivers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: shared-resource-csi-driver-operator-clusterrole

--- a/manifests/07_role_shared_resource_config.yaml
+++ b/manifests/07_role_shared_resource_config.yaml
@@ -1,0 +1,15 @@
+# Allow AWS EBS CSI driver operator to read CA bundle from openshift-config-managed/kube-cloud-config ConfigMap
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: shared-resource-csi-driver-operator-aws-config-role
+  namespace: openshift-config-managed
+rules:
+- apiGroups:
+  - ''
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - list
+  - watch

--- a/manifests/08_rolebinding_shared_resource_config.yaml
+++ b/manifests/08_rolebinding_shared_resource_config.yaml
@@ -1,0 +1,13 @@
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: shared-resource-csi-driver-operator-aws-config-clusterrolebinding
+  namespace: openshift-config-managed
+subjects:
+  - kind: ServiceAccount
+    name: shared-resource-csi-driver-operator
+    namespace: openshift-cluster-csi-drivers
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: shared-resource-csi-driver-operator-aws-config-role

--- a/manifests/09_deployment.yaml
+++ b/manifests/09_deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: shared-resource-csi-driver-operator
+  namespace: openshift-cluster-csi-drivers
+spec:
+  selector:
+    matchLabels:
+      name: shared-resource-csi-driver-operator
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        name: shared-resource-csi-driver-operator
+    spec:
+      containers:
+      - args:
+        - start
+        - -v=${LOG_LEVEL}
+        env:
+        - name: DRIVER_IMAGE
+          value: ${DRIVER_IMAGE}
+        - name: NODE_DRIVER_REGISTRAR_IMAGE
+          value: ${NODE_DRIVER_REGISTRAR_IMAGE}
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        image: ${OPERATOR_IMAGE}
+        imagePullPolicy: IfNotPresent
+        name: shared-resource-csi-driver-operator
+        resources:
+          requests:
+            memory: 50Mi
+            cpu: 10m
+      priorityClassName: system-cluster-critical
+      serviceAccountName: shared-resource-csi-driver-operator
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: "NoSchedule"


### PR DESCRIPTION
- Add a script that can be used to deploy the operator. This is a
  temporary measure until we are fully integrated with the cluster
  storage operator.
- Add placeholder e2e script.
- Add manifests to deploy the operator, with placeholder variables for image names and common configuration.