### PR TITLE
BUILD-284: Mark driver as managed by OCP CSI operator

### DIFF
--- a/assets/csidriver.yaml
+++ b/assets/csidriver.yaml
@@ -2,6 +2,9 @@ apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: csi.sharedresource.openshift.io
+  annotations:
+    # This CSIDriver is managed by an OCP CSI operator
+    csi.openshift.io/managed: "true"
 spec:
   # Supports ephemeral inline volumes.
   volumeLifecycleModes:

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -67,6 +67,9 @@ var _csidriverYaml = []byte(`apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:
   name: csi.sharedresource.openshift.io
+  annotations:
+    # This CSIDriver is managed by an OCP CSI operator
+    csi.openshift.io/managed: "true"
 spec:
   # Supports ephemeral inline volumes.
   volumeLifecycleModes:


### PR DESCRIPTION
Adds annotation to CSIDriver yaml that marks this as managed by the OCP CSI operator