### PR TITLE
BUILD-256: add driver config configmap to operator manifest

### DIFF
--- a/manifests/13_cfg_configmap.yaml
+++ b/manifests/13_cfg_configmap.yaml
@@ -1,0 +1,5 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: csi-driver-shared-resource-config
+  namespace: openshift-cluster-csi-drivers


### PR DESCRIPTION
to facilitate my revival of the no refresh resources e2e in the driver repo ... hope to get that PR up later today

/assign @coreydaley 

@otaviof FYI

see https://github.com/openshift/cluster-openshift-controller-manager-operator/blob/master/manifests/05_builder-deployer-config.yaml for precedence of including "configuration" config maps in operator manifests