### PR TITLE
Use bidirectional mountPropagation and hostPath volume under /run

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -38,7 +38,7 @@ spec:
               name: socket-dir
             - mountPath: /registration
               name: registration-dir
-            - mountPath: /csi-data-dir
+            - mountPath: /run/csi-data-dir
               name: csi-data-dir
 
         - name: hostpath
@@ -78,8 +78,9 @@ spec:
             - mountPath: /var/lib/kubelet/plugins
               mountPropagation: Bidirectional
               name: plugins-dir
-            - mountPath: /csi-data-dir
+            - mountPath: /run/csi-data-dir
               name: csi-data-dir
+              mountPropagation: Bidirectional
             - mountPath: /csi-volumes-map
               name: csi-volumes-map
             - mountPath: /dev
@@ -110,9 +111,10 @@ spec:
             path: /var/lib/csi-volumes-map/
             type: DirectoryOrCreate
           name: csi-volumes-map
-        - emptyDir:
-            # this tells Kubernetes to mount a tmpfs (RAM-backed filesystem)
-            medium: Memory
+        - hostPath:
+          # hostPath under /run are mounted as a tmpfs (RAM-backed filesystem)
+            path: /run/csi-data-dir
+            type: DirectoryOrCreate
           name: csi-data-dir
         - hostPath:
             path: /dev

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -170,7 +170,7 @@ spec:
               name: socket-dir
             - mountPath: /registration
               name: registration-dir
-            - mountPath: /csi-data-dir
+            - mountPath: /run/csi-data-dir
               name: csi-data-dir
 
         - name: hostpath
@@ -210,8 +210,9 @@ spec:
             - mountPath: /var/lib/kubelet/plugins
               mountPropagation: Bidirectional
               name: plugins-dir
-            - mountPath: /csi-data-dir
+            - mountPath: /run/csi-data-dir
               name: csi-data-dir
+              mountPropagation: Bidirectional
             - mountPath: /csi-volumes-map
               name: csi-volumes-map
             - mountPath: /dev
@@ -242,9 +243,10 @@ spec:
             path: /var/lib/csi-volumes-map/
             type: DirectoryOrCreate
           name: csi-volumes-map
-        - emptyDir:
-            # this tells Kubernetes to mount a tmpfs (RAM-backed filesystem)
-            medium: Memory
+        - hostPath:
+          # hostPath under /run are mounted as a tmpfs (RAM-backed filesystem)
+            path: /run/csi-data-dir
+            type: DirectoryOrCreate
           name: csi-data-dir
         - hostPath:
             path: /dev


### PR DESCRIPTION
Related to https://github.com/openshift/csi-driver-shared-resource/pull/63 which is a fix for emptyDir readonly volumes not being properly remounted on driver restart.