### PR TITLE
Block server_test until metrics server is up

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/prometheus/common v0.26.0
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5
+	k8s.io/api v0.22.1
 	k8s.io/apiextensions-apiserver v0.22.1
 	k8s.io/apimachinery v0.22.1
 	k8s.io/client-go v0.22.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -488,6 +488,7 @@ gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 gopkg.in/yaml.v3
 # k8s.io/api v0.22.1
+## explicit
 k8s.io/api/admission/v1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1


### PR DESCRIPTION
In some cases it is possible that client is trying to access the server that might not yet be up. In this case, `http` client returns the `connection refused` error.
So, in case of this error, we should try to wait a bit for the metrics server to be up.