### PR TITLE
Rename csi shares amount metric

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -19,8 +19,8 @@ const (
 	cm     = "configmap"
 	secret = "secret"
 
-	cmCountName     = sharesSubsystem + separator + cm + separator + "total"
-	secretCountName = sharesSubsystem + separator + secret + separator + "total"
+	cmCountName     = sharesSubsystem + separator + cm
+	secretCountName = sharesSubsystem + separator + secret
 
 	MetricsPort = 6000
 )

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -73,12 +73,12 @@ func TestMetrics(t *testing.T) {
 		{
 			name: "One secret, one config map",
 			expected: []string{
-				"# HELP openshift_csi_share_configmap_total Counts ConfigMap objects shared by the CSI shared resource driver",
-				"# TYPE openshift_csi_share_configmap_total gauge",
-				"openshift_csi_share_configmap_total 1",
-				"# HELP openshift_csi_share_secret_total Counts Secret objects shared by the CSI shared resource driver",
-				"# TYPE openshift_csi_share_secret_total gauge",
-				"openshift_csi_share_secret_total 1",
+				"# HELP openshift_csi_share_configmap Counts ConfigMap objects shared by the CSI shared resource driver",
+				"# TYPE openshift_csi_share_configmap gauge",
+				"openshift_csi_share_configmap 1",
+				"# HELP openshift_csi_share_secret Counts Secret objects shared by the CSI shared resource driver",
+				"# TYPE openshift_csi_share_secret gauge",
+				"openshift_csi_share_secret 1",
 			},
 			secretLister: &fakeSecretShareLister{
 				secretShares: []*v1alpha1.SharedSecret{
@@ -108,12 +108,12 @@ func TestMetrics(t *testing.T) {
 		{
 			name: "Two secrets, no config maps",
 			expected: []string{
-				"# HELP openshift_csi_share_secret_total Counts Secret objects shared by the CSI shared resource driver",
-				"# TYPE openshift_csi_share_secret_total gauge",
-				"openshift_csi_share_secret_total 2",
-				"# HELP openshift_csi_share_configmap_total Counts ConfigMap objects shared by the CSI shared resource driver",
-				"# TYPE openshift_csi_share_configmap_total gauge",
-				"openshift_csi_share_configmap_total 0",
+				"# HELP openshift_csi_share_secret Counts Secret objects shared by the CSI shared resource driver",
+				"# TYPE openshift_csi_share_secret gauge",
+				"openshift_csi_share_secret 2",
+				"# HELP openshift_csi_share_configmap Counts ConfigMap objects shared by the CSI shared resource driver",
+				"# TYPE openshift_csi_share_configmap gauge",
+				"openshift_csi_share_configmap 0",
 			},
 			secretLister: &fakeSecretShareLister{
 				secretShares: []*v1alpha1.SharedSecret{
@@ -142,12 +142,12 @@ func TestMetrics(t *testing.T) {
 		{
 			name: "No secrets, two config maps",
 			expected: []string{
-				"# HELP openshift_csi_share_configmap_total Counts ConfigMap objects shared by the CSI shared resource driver",
-				"# TYPE openshift_csi_share_configmap_total gauge",
-				"openshift_csi_share_configmap_total 2",
-				"# HELP openshift_csi_share_secret_total Counts Secret objects shared by the CSI shared resource driver",
-				"# TYPE openshift_csi_share_secret_total gauge",
-				"openshift_csi_share_secret_total 0",
+				"# HELP openshift_csi_share_configmap Counts ConfigMap objects shared by the CSI shared resource driver",
+				"# TYPE openshift_csi_share_configmap gauge",
+				"openshift_csi_share_configmap 2",
+				"# HELP openshift_csi_share_secret Counts Secret objects shared by the CSI shared resource driver",
+				"# TYPE openshift_csi_share_secret gauge",
+				"openshift_csi_share_secret 0",
 			},
 			secretLister: &fakeSecretShareLister{
 				secretShares: []*v1alpha1.SharedSecret{},

--- a/pkg/metrics/server_test.go
+++ b/pkg/metrics/server_test.go
@@ -113,8 +113,8 @@ func TestMetricQueries(t *testing.T) {
 		{
 			name: "One secret, one config map",
 			expected: []queryResult{
-				{"openshift_csi_share_configmap_total", 1},
-				{"openshift_csi_share_secret_total", 1},
+				{"openshift_csi_share_configmap", 1},
+				{"openshift_csi_share_secret", 1},
 			},
 			secretLister: &fakeSecretShareLister{
 				secretShares: []*v1alpha1.SharedSecret{
@@ -144,8 +144,8 @@ func TestMetricQueries(t *testing.T) {
 		{
 			name: "Two secrets, no config maps",
 			expected: []queryResult{
-				{"openshift_csi_share_secret_total", 2},
-				{"openshift_csi_share_configmap_total", 0},
+				{"openshift_csi_share_secret", 2},
+				{"openshift_csi_share_configmap", 0},
 			},
 			secretLister: &fakeSecretShareLister{
 				secretShares: []*v1alpha1.SharedSecret{
@@ -174,8 +174,8 @@ func TestMetricQueries(t *testing.T) {
 		{
 			name: "No secrets, two config maps",
 			expected: []queryResult{
-				{"openshift_csi_share_configmap_total", 2},
-				{"openshift_csi_share_secret_total", 0},
+				{"openshift_csi_share_configmap", 2},
+				{"openshift_csi_share_secret", 0},
 			},
 			secretLister: &fakeSecretShareLister{
 				secretShares: []*v1alpha1.SharedSecret{},


### PR DESCRIPTION
According to best practices, gauge metrics should not contain `_total` suffix in its name.