### PR TITLE
CSI SR node TLS cert and port, operator metrics server supports TLS

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -72,8 +72,8 @@ spec:
             - containerPort: 9898
               name: healthz
               protocol: TCP
-            - containerPort: 6000
-              name: metrics
+            - name: provisioner-m
+              containerPort: 6000
               protocol: TCP
           volumeMounts:
             - mountPath: /var/run/configmaps/config
@@ -93,6 +93,8 @@ spec:
               name: csi-volumes-map
             - mountPath: /dev
               name: dev-dir
+            - mountPath: /etc/secrets
+              name: shared-resource-csi-driver-node-metrics-serving-cert
           resources:
             requests:
               cpu: 10m
@@ -131,3 +133,7 @@ spec:
             path: /dev
             type: Directory
           name: dev-dir
+        - name: shared-resource-csi-driver-node-metrics-serving-cert
+          secret:
+            defaultMode: 420
+            secretName: shared-resource-csi-driver-node-metrics-serving-cert

--- a/pkg/generated/bindata.go
+++ b/pkg/generated/bindata.go
@@ -273,8 +273,8 @@ spec:
             - containerPort: 9898
               name: healthz
               protocol: TCP
-            - containerPort: 6000
-              name: metrics
+            - name: provisioner-m
+              containerPort: 6000
               protocol: TCP
           volumeMounts:
             - mountPath: /var/run/configmaps/config
@@ -294,6 +294,8 @@ spec:
               name: csi-volumes-map
             - mountPath: /dev
               name: dev-dir
+            - mountPath: /etc/secrets
+              name: shared-resource-csi-driver-node-metrics-serving-cert
           resources:
             requests:
               cpu: 10m
@@ -332,6 +334,10 @@ spec:
             path: /dev
             type: Directory
           name: dev-dir
+        - name: shared-resource-csi-driver-node-metrics-serving-cert
+          secret:
+            defaultMode: 420
+            secretName: shared-resource-csi-driver-node-metrics-serving-cert
 `)
 
 func nodeYamlBytes() ([]byte, error) {

--- a/pkg/metrics/server.go
+++ b/pkg/metrics/server.go
@@ -10,6 +10,11 @@ import (
 	"k8s.io/klog/v2"
 )
 
+var (
+	tlsCRT = "/etc/secrets/tls.crt"
+	tlsKey = "/etc/secrets/tls.key"
+)
+
 // BuildServer creates the http.Server struct
 func BuildServer(port int) *http.Server {
 	if port <= 0 {
@@ -40,7 +45,7 @@ func StopServer(srv *http.Server) {
 // RunServer starts the metrics server.
 func RunServer(srv *http.Server, stopCh <-chan struct{}) {
 	go func() {
-		err := srv.ListenAndServe()
+		err := srv.ListenAndServeTLS(tlsCRT, tlsKey)
 		if err != nil && err != http.ErrServerClosed {
 			klog.Errorf("error starting metrics server: %v", err)
 		}

--- a/pkg/metrics/server_test.go
+++ b/pkg/metrics/server_test.go
@@ -1,9 +1,18 @@
 package metrics
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"math/big"
+	mr "math/rand"
 	"net/http"
+	"os"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -22,9 +31,67 @@ var (
 	portOffset uint32 = 0
 )
 
+func TestMain(m *testing.M) {
+	var err error
+
+	mr.Seed(time.Now().UnixNano())
+
+	tlsKey, tlsCRT, err = generateTempCertificates()
+	if err != nil {
+		panic(err)
+	}
+
+	// sets the default http client to skip certificate check.
+	http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
+		InsecureSkipVerify: true,
+	}
+
+	code := m.Run()
+	os.Remove(tlsKey)
+	os.Remove(tlsCRT)
+	os.Exit(code)
+}
+
+func generateTempCertificates() (string, string, error) {
+	key, err := rsa.GenerateKey(rand.Reader, 1024)
+	if err != nil {
+		return "", "", err
+	}
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+	}
+	derBytes, err := x509.CreateCertificate(rand.Reader, &template, &template, key.Public(), key)
+	if err != nil {
+		return "", "", err
+	}
+
+	cert, err := ioutil.TempFile("", "testcert-")
+	if err != nil {
+		return "", "", err
+	}
+	defer cert.Close()
+	pem.Encode(cert, &pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: derBytes,
+	})
+
+	keyPath, err := ioutil.TempFile("", "testkey-")
+	if err != nil {
+		return "", "", err
+	}
+	defer keyPath.Close()
+	pem.Encode(keyPath, &pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: x509.MarshalPKCS1PrivateKey(key),
+	})
+
+	return keyPath.Name(), cert.Name(), nil
+}
+
 func blockUntilServerStarted(port int) error {
 	return wait.PollImmediate(100*time.Millisecond, 5*time.Second, func() (bool, error) {
-		if _, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", port)); err != nil {
+		if _, err := http.Get(fmt.Sprintf("https://localhost:%d/metrics", port)); err != nil {
 			// in case error is "connection refused", server is not up (yet)
 			// it is possible that it is still being started
 			// in that case we need to try more
@@ -59,7 +126,7 @@ func TestRunServer(t *testing.T) {
 	port, ch := runMetricsServer(t)
 	defer close(ch)
 
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", port))
+	resp, err := http.Get(fmt.Sprintf("https://localhost:%d/metrics", port))
 	if err != nil {
 		t.Fatalf("error while querying metrics server: %v", err)
 	}
@@ -70,7 +137,7 @@ func TestRunServer(t *testing.T) {
 }
 
 func testQueryGaugeMetric(t *testing.T, testName string, port, value int, query string) {
-	resp, err := http.Get(fmt.Sprintf("http://localhost:%d/metrics", port))
+	resp, err := http.Get(fmt.Sprintf("https://localhost:%d/metrics", port))
 	if err != nil {
 		t.Fatalf("error requesting metrics server: %v in test %q", err, testName)
 	}


### PR DESCRIPTION
CSI shared resource driver node pod must be deployed with port with correct name so that service can find it, and TLS certificate should be mounted into the container.
Besides that, metrics server in the operator must now support TLS.