### PR TITLE
update registrar kubelet socket location to mirror what other CSI drivers do

### DIFF
--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -26,7 +26,7 @@ spec:
           args:
             - --v=5
             - --csi-address=/csi/csi.sock
-            - --kubelet-registration-path=/var/lib/kubelet/plugins/csi-hostpath/csi.sock
+            - --kubelet-registration-path=/var/lib/kubelet/plugins/sharedresource.csi.openshift.com/csi.sock
           securityContext:
             # This is necessary only for systems with SELinux, where
             # non-privileged sidecar containers cannot access unix domain socket
@@ -105,7 +105,7 @@ spec:
             name: csi-driver-shared-resource-config
           name: config
         - hostPath:
-            path: /var/lib/kubelet/plugins/csi-hostpath
+            path: /var/lib/kubelet/plugins/sharedresource.csi.openshift.com
             type: DirectoryOrCreate
           name: socket-dir
         - hostPath:


### PR DESCRIPTION
Fixes https://github.com/openshift/csi-driver-shared-resource/issues/74

examples from other csi drivers:
- /var/lib/kubelet/plugins/file.csi.azure.com/csi.sock
- /var/lib/kubelet/plugins/efs.csi.aws.com/csi.sock