### PR TITLE
OCPBUGS-3358: Revert "[build-407] Mount shared secret and configmap list config path into shared driver node"

### DIFF
--- a/assets/config_configmap.yaml
+++ b/assets/config_configmap.yaml
@@ -31,12 +31,7 @@ data:
       - openshift-machine-config-operator
       - openshift-sdn
       - openshift-service-ca-operator
+
     refreshResources: true
+
     shareRelistInterval: 10m
-  sharedconfigmap-list.yaml: |
-    ---
-    authorizedSharedResources:
-  sharedsecret-list.yaml: |
-    ---
-    authorizedSharedResources:
-      - openshift-etc-pki-entitlement: openshift-config-managed:etc-pki-entitlement

--- a/assets/node.yaml
+++ b/assets/node.yaml
@@ -57,8 +57,6 @@ spec:
             - csi-driver-shared-resource
           args:
             - --config=/var/run/configmaps/config/config.yaml
-            - --config=/var/run/configmaps/config/sharedconfigmap-list.yaml
-            - --config=/var/run/configmaps/config/sharedsecret-list.yaml
             - "--drivername=csi.sharedresource.openshift.io"
             - "--v=4"
             - "--nodeid=$(KUBE_NODE_NAME)"

--- a/assets/sharedconfigmaplist_configmap.yaml
+++ b/assets/sharedconfigmaplist_configmap.yaml
@@ -1,0 +1,9 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ocp-sharedconfigmap-list
+  namespace: openshift-cluster-csi-drivers
+data:
+  sharedconfigmap-list.yaml: |
+    ---
+    authorizedSharedResources:

--- a/assets/sharedsecretlist_configmap.yaml
+++ b/assets/sharedsecretlist_configmap.yaml
@@ -1,0 +1,10 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ocp-sharedsecret-list
+  namespace: openshift-cluster-csi-drivers
+data:
+  sharedsecret-list.yaml: |
+    ---
+    authorizedSharedResources:
+      - openshift-etc-pki-entitlement: openshift-config-managed:etc-pki-entitlement


### PR DESCRIPTION
Reverts openshift/csi-driver-shared-resource-operator#56