### PR TITLE
BUILD-407: remove pod wrapper types from validating webhook config

### DIFF
--- a/assets/webhook/validating_webhook_configuration.yaml
+++ b/assets/webhook/validating_webhook_configuration.yaml
@@ -40,15 +40,5 @@ webhooks:
       apiVersions: ["v1", "v1beta1", "v1alpha1"]
       resources: ["sharedsecrets", "sharedconfigmaps"]
       scope: "*"
-    - operations: ["CREATE", "UPDATE"]
-      apiGroups: ["apps"]
-      apiVersions: ["v1", "v1beta1"]
-      resources: ["deployments", "daemonset"]
-      scope: "*"
-    - operations: ["CREATE", "UPDATE"]
-      apiGroups: ["apps.openshift.io"]
-      apiVersions: ["v1"]
-      resources: ["deploymentconfigs"]
-      scope: "*"
   sideEffects: None
   timeoutSeconds: 10


### PR DESCRIPTION
/assign @coreydaley 

- the original webhook introduction did not lead to processing deployments, deploymentconfigs, etc.
- failure on the pod creation will be reflected in their status, so the ease of use difference is minor for users
- and most notably, we reduced the traffic going into the webhook by a good bit; this will help as we move from tech preview to GA