### PR TITLE
OCPBUGS-26087: add snyk config file for SAST scan

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,6 @@
+# References:
+# https://docs.snyk.io/scan-applications/snyk-code/using-snyk-code-from-the-cli/excluding-directories-and-files-from-the-snyk-code-cli-test
+# https://docs.snyk.io/snyk-cli/commands/ignore
+exclude:
+  global:
+    - vendor/**


### PR DESCRIPTION
Per the documented policy from ART for the SAST scans, and following the pattern established in the openshift/oc repo, we are introducing a snyk config file that excludes the vendor tree, as that is currently some minor warnings.